### PR TITLE
Fix [IPFHOME-74] News 화면 내 페이징 관련 버그 수정

### DIFF
--- a/src/pages/news.tsx
+++ b/src/pages/news.tsx
@@ -136,7 +136,7 @@ export default function News() {
         data-sal-easing="ease"
       >
         {newsData[0].title != ''
-          ? displayAllNewsData(newsData, paginationData.selectedPage)
+          ? displayAllNewsData(newsData, paginationData.selectedPage - 1)
           : displayNewsItemSkeleton()}
 
         <SpindleThemeProvider theme={theme}>


### PR DESCRIPTION
https://ipf-jira.atlassian.net/browse/IPFHOME-74

News 화면에서 페이징 관련 버그로 인해 0~7번째 배열에 있는 데이터가 출력되지 않는 현상 수정

https://user-images.githubusercontent.com/109952646/185340639-829ae906-85c7-4eae-b24b-059142e2471b.mov
