### PR TITLE
Fix [IPFHOME-75] Career페이지 이름 변경 및 링크 변경

### DIFF
--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -77,8 +77,8 @@ export default function HamburgerMenu({ open, onClick }: HamburgerMenuProps) {
           </LinkStyled>
         </Gap>
         <Gap>
-          <LinkStyled activeStyle={{ color: colors.primary }} to="/career/">
-            Career
+          <LinkStyled activeStyle={{ color: colors.primary }} to="/careers/">
+            Careers
           </LinkStyled>
         </Gap>
         <Gap>

--- a/src/components/JobItem.tsx
+++ b/src/components/JobItem.tsx
@@ -109,7 +109,7 @@ export default function JobItem({ jobItemData }: Props) {
       key={jobItemData.title}
     >
       <Item
-        to={`/career/job?id=${jobItemData.id}`}
+        to={`/careers/job?id=${jobItemData.id}`}
         state={{ details: jobItemData.details }}
       >
         <DescriptionContainer>

--- a/src/containers/Navigation.tsx
+++ b/src/containers/Navigation.tsx
@@ -288,14 +288,14 @@ function Navigation({ mode = 'light' }: Props) {
               News
             </LinkStyled>
           </li>
-          <li key="career">
+          <li key="careers">
             <LinkStyled
               linkcolor={headerColor.linkcolor}
               backgroundcolor={headerColor.backgroundcolor}
               activeStyle={LinkActiveStyle}
-              to="/career/"
+              to="/careers/"
             >
-              Career
+              Careers
             </LinkStyled>
           </li>
           <li key="contact">

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -100,7 +100,7 @@
   "TEXT-05": "Globally Adopted, \nCommercially Proven",
   "TEXT-06": "News",
   "TEXT-07": "iPortfolio in the Media",
-  "TEXT-08": "Career",
+  "TEXT-08": "Careers",
   "TEXT-09": "Apply Now and Reform Education!",
   "TEXT-10": "Bett 2020 Highlights",
   "TEXT-11": "세계 최대 EdTech 전시회인 BETT 2020이 열린 영국 런던에서 아이포트폴리오 임직원들이 발견한 88개의 주목할만한 기업들과 직접 인터뷰한 내용을 보고서로 발간하였습니다. 수령을 희망하시는 분들은 리포트 신청서를 작성해주세요.",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -100,7 +100,7 @@
   "TEXT-05": "Globally Adopted, \nCommercially Proven",
   "TEXT-06": "News",
   "TEXT-07": "iPortfolio in the Media",
-  "TEXT-08": "Career",
+  "TEXT-08": "Careers",
   "TEXT-09": "Apply Now and Reform Education!",
   "TEXT-10": "Bett 2020 Highlights",
   "TEXT-11": "세계 최대 EdTech 전시회인 BETT 2020이 열린 영국 런던에서 아이포트폴리오 임직원들이 발견한 88개의 주목할만한 기업들과 직접 인터뷰한 내용을 보고서로 발간하였습니다.\n수령을 희망하시는 분들은 리포트 신청서를 작성해주세요.",

--- a/src/pages/careers.tsx
+++ b/src/pages/careers.tsx
@@ -13,11 +13,11 @@ import JobSection from '../sections/Career/JobSection';
 import Footer from '../containers/Footer';
 import FloatingButton from '../components/FloatingButton';
 
-export default function Career() {
+export default function Careers() {
   const { t } = useTranslation();
   return (
     <>
-      <HelmetComponent pageTitle="Career" pageLink="/career" />
+      <HelmetComponent pageTitle="Careers" pageLink="/careers" />
       <div style={{ width: '100%', height: '100%' }}>
         <Header>{t('TEXT-08')}</Header>
         <IntroSection />

--- a/src/pages/careers/job.tsx
+++ b/src/pages/careers/job.tsx
@@ -209,10 +209,10 @@ export default function Job({ location }: Props) {
       <HelmetComponent
         pageTitle={`${
           jobsData[0].depth != 0 ? jobsData[0].title.replace('\n', '') : ''
-        } 채용 - Career`}
-        pageLink={`/career/job/?id=${urlParams.get('id')}`}
+        } 채용 - Careers`}
+        pageLink={`/careers/job/?id=${urlParams.get('id')}`}
       />
-      <Header>Career</Header>
+      <Header>Careers</Header>
       <ContainerStyled
         data-sal="slide-up"
         data-sal-duration="1000"

--- a/src/sections/Home/CareerSection.tsx
+++ b/src/sections/Home/CareerSection.tsx
@@ -37,7 +37,7 @@ export default function CareerSection() {
           >
             {t('HPG-3')}
           </Description>
-          <Button onClick={() => navigate('/career')}>{t('HPG-4')}</Button>
+          <Button onClick={() => navigate('/careers')}>{t('HPG-4')}</Button>
         </Column>
       </ContainerStyled>
       <PhotoCarouselHome />


### PR DESCRIPTION
[[IPFHOME-75] Career페이지 이름 변경 및 링크 변경](https://ipf-jira.atlassian.net/browse/IPFHOME-75) 

'Career'를 'Careers'로 수정했습니다. (페이지 내 텍스트 & URL)

[웹 - Careers 페이지]
<img width="1422" alt="image" src="https://user-images.githubusercontent.com/109952646/187866846-0b48a3a0-9dc7-4b19-99d0-4d8334ce2c21.png">

[웹 - Careers > 상세 페이지]
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/109952646/187866913-509dd457-722b-461f-9072-77b112e0548f.png">

[모바일]
<img width="372" alt="image" src="https://user-images.githubusercontent.com/109952646/187866973-e1dc016a-51c8-479b-a99f-753b4f2870d9.png">
