### PR TITLE
Fix [IPFHOME-75] Carrers URL을 /career로 변경

### DIFF
--- a/src/components/HamburgerMenu.tsx
+++ b/src/components/HamburgerMenu.tsx
@@ -77,7 +77,7 @@ export default function HamburgerMenu({ open, onClick }: HamburgerMenuProps) {
           </LinkStyled>
         </Gap>
         <Gap>
-          <LinkStyled activeStyle={{ color: colors.primary }} to="/careers/">
+          <LinkStyled activeStyle={{ color: colors.primary }} to="/career/">
             Careers
           </LinkStyled>
         </Gap>

--- a/src/components/JobItem.tsx
+++ b/src/components/JobItem.tsx
@@ -109,7 +109,7 @@ export default function JobItem({ jobItemData }: Props) {
       key={jobItemData.title}
     >
       <Item
-        to={`/careers/job?id=${jobItemData.id}`}
+        to={`/career/job?id=${jobItemData.id}`}
         state={{ details: jobItemData.details }}
       >
         <DescriptionContainer>

--- a/src/containers/Navigation.tsx
+++ b/src/containers/Navigation.tsx
@@ -288,12 +288,12 @@ function Navigation({ mode = 'light' }: Props) {
               News
             </LinkStyled>
           </li>
-          <li key="careers">
+          <li key="career">
             <LinkStyled
               linkcolor={headerColor.linkcolor}
               backgroundcolor={headerColor.backgroundcolor}
               activeStyle={LinkActiveStyle}
-              to="/careers/"
+              to="/career/"
             >
               Careers
             </LinkStyled>

--- a/src/pages/career.tsx
+++ b/src/pages/career.tsx
@@ -13,11 +13,11 @@ import JobSection from '../sections/Career/JobSection';
 import Footer from '../containers/Footer';
 import FloatingButton from '../components/FloatingButton';
 
-export default function Careers() {
+export default function Career() {
   const { t } = useTranslation();
   return (
     <>
-      <HelmetComponent pageTitle="Careers" pageLink="/careers" />
+      <HelmetComponent pageTitle="Career" pageLink="/career" />
       <div style={{ width: '100%', height: '100%' }}>
         <Header>{t('TEXT-08')}</Header>
         <IntroSection />

--- a/src/pages/career/job.tsx
+++ b/src/pages/career/job.tsx
@@ -210,7 +210,7 @@ export default function Job({ location }: Props) {
         pageTitle={`${
           jobsData[0].depth != 0 ? jobsData[0].title.replace('\n', '') : ''
         } 채용 - Careers`}
-        pageLink={`/careers/job/?id=${urlParams.get('id')}`}
+        pageLink={`/career/job/?id=${urlParams.get('id')}`}
       />
       <Header>Careers</Header>
       <ContainerStyled

--- a/src/sections/Home/CareerSection.tsx
+++ b/src/sections/Home/CareerSection.tsx
@@ -37,7 +37,7 @@ export default function CareerSection() {
           >
             {t('HPG-3')}
           </Description>
-          <Button onClick={() => navigate('/careers')}>{t('HPG-4')}</Button>
+          <Button onClick={() => navigate('/career')}>{t('HPG-4')}</Button>
         </Column>
       </ContainerStyled>
       <PhotoCarouselHome />


### PR DESCRIPTION
[변경사항]
지원자들에게 이메일로 공유한 채용 URL이 이미 /career로 보내져 지원자들이 채용공고를 볼 수 없는 상황이 생
홈페이지 URL을 /careers 에서 /career로 변경했습니다.

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/109952646/188070703-3864a23f-614d-4bfb-854b-84ad0aa988c4.png">

<img width="1425" alt="image" src="https://user-images.githubusercontent.com/109952646/188070972-65225af1-8b47-4982-a4bd-23b392aa78f1.png">

