### PR TITLE
Implement [IPFHOME-81] 채용 공고 상세 > 리스트 아이템 마커 제대로 표시되도록 수정

### DIFF
--- a/src/pages/career/job.tsx
+++ b/src/pages/career/job.tsx
@@ -139,7 +139,17 @@ function displayJobDetail(jobsDetailData: [JobDetailType]) {
           <DiscList key={`${jobDetail.title.replace('\n', '')}_${index}`}>
             <Heading4>{jobDetail.title}</Heading4>
             <CircleList>
-              <Body3 as="li">{jobDetail.content}</Body3>
+              {jobDetail.content.split('\n').map((value, index, arr) => {
+                if (index === arr.length - 1) {
+                  return null;
+                }
+
+                return (
+                  <Body3 as="li" key={value}>
+                    {value}
+                  </Body3>
+                );
+              })}
             </CircleList>
           </DiscList>
         );

--- a/src/pages/career/job.tsx
+++ b/src/pages/career/job.tsx
@@ -87,6 +87,12 @@ const Body3 = styled.p`
   white-space: pre-line;
 `;
 
+const Body3Li = styled(Body3).attrs({ as: 'li' })`
+  &:not(:last-child) {
+    margin-bottom: 0.4rem;
+  }
+`;
+
 const DiscList = styled.ul`
   list-style: disc;
   list-style-position: inside;
@@ -144,11 +150,7 @@ function displayJobDetail(jobsDetailData: [JobDetailType]) {
                   return null;
                 }
 
-                return (
-                  <Body3 as="li" key={value}>
-                    {value}
-                  </Body3>
-                );
+                return <Body3Li key={value}>{value}</Body3Li>;
               })}
             </CircleList>
           </DiscList>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1541,9 +1541,9 @@
   integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
 "@ipf-dev/eslint-config-iportfolio@^0.2.5":
-  version "0.7.0"
-  resolved "https://npm.pkg.github.com/download/@ipf-dev/eslint-config-iportfolio/0.7.0/ab4b6bcbcf2459775a34e7f0e29edd924e1f6faba1f15375defcdab61c133969#cf1fba25d7a8b8263a79f727cfed4b7c4acf68b3"
-  integrity sha512-hI4FObEU0G+wIh/iMP3IsyCDi8pR4Uo25cv53Lt1INIELDAb50fBUvBs2fP4SG4OqeJr2uI2LsfqLHckKBeoyw==
+  version "1.0.4"
+  resolved "https://npm.pkg.github.com/download/@ipf-dev/eslint-config-iportfolio/1.0.4/9f50a76033312eaca4d619566c7dbfb24f17cf73#9f50a76033312eaca4d619566c7dbfb24f17cf73"
+  integrity sha512-j2aoLixwaN4u5h3sF6XsUpTeA7NYhsZc6jcfsM6KivduND1l2kV+Lx0lAha7fg7wP00/fyL4e9goBgLNnOkTiA==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^4.7.0"
     "@typescript-eslint/parser" "^4.7.0"


### PR DESCRIPTION
#### 원인
- 위계에 따라 (e.g., `제목3`, `제목4`) 스타일이 지정됨
- career 상세 `content` 하나당 하나의 `<li>`로 처리됨

#### 해결
- `depth = 4`인 career 상세 `content`를 `\n`로 구분하고, 각 문자열을 `li`로 표시
  
#### 결과
<img width="960" alt="image" src="https://github.com/ipf-dev/ipf-homepage-new/assets/97017196/4c8eef95-2008-4f3c-b704-fbed4606c87d">

#### 참고
- [IPFHOME-81](https://ipf-jira.atlassian.net/browse/IPFHOME-81)
- [career 상세 조회 api](https://ipf-jira.atlassian.net/wiki/spaces/SL/pages/759562245/iPF+Internal+App+Data+API#Career---%EC%83%81%EC%84%B8-%EB%82%B4%EC%9A%A9-%EC%A1%B0%ED%9A%8C)