### PR TITLE
Fix [] 하단 마진 수정

### DIFF
--- a/src/sections/About/HistorySection.tsx
+++ b/src/sections/About/HistorySection.tsx
@@ -218,7 +218,6 @@ export default function HistorySection() {
             },
             { month: t('TEXT-23'), items: [t('HPG-29')] },
           ]}
-          style={{ marginBottom: 0 }}
         />
         <TimeLine
           year={t('YEAR-2021')}
@@ -236,7 +235,6 @@ export default function HistorySection() {
               items: [t('HPG-92')],
             },
           ]}
-          style={{ marginBottom: 0 }}
         />
         <TimeLine
           year={t('YEAR-2022')}
@@ -250,7 +248,6 @@ export default function HistorySection() {
               items: [t('HPG-95')],
             },
           ]}
-          style={{ marginBottom: 0 }}
         />
         <TimeLine hidden year="" description={[{ month: '', items: [''] }]} />
       </HistoryDescriptionContainer>


### PR DESCRIPTION
#### 하단 마진 수정
일부 년도 `TimeLine`에서 누락된 하단 마진 추가
- As-Is
  <img width="446" alt="image" src="https://github.com/ipf-dev/ipf-homepage-new/assets/97017196/980ff831-400b-4620-8698-989a05c3ae2f">
- To-Be
  <img width="378" alt="image" src="https://github.com/ipf-dev/ipf-homepage-new/assets/97017196/cd5e0964-c40c-45cf-ae84-9ede35e84765">
